### PR TITLE
Add no-nested-ternary to eslint rules

### DIFF
--- a/.github/actions/publish/action.yaml
+++ b/.github/actions/publish/action.yaml
@@ -2,12 +2,8 @@ name: 'Publish to NPM'
 description: 'Publish a package to NPM'
 
 inputs:
-  name:
-    description: 'Package name, used to tag release commits'
-    required: true
-
   package:
-    description: 'Path to package.json'
+    description: 'Path to package'
     required: true
 
   token:
@@ -19,18 +15,18 @@ runs:
   steps:
     - id: publish
       name: Publish package
-      uses: JS-DevTools/npm-publish@1641d030cee266f093503c555ee9303ae7aede16
+      uses: JS-DevTools/npm-publish@0be441d808570461daedc3fb178405dbcac54de0
       with:
         package: ${{ inputs.package }}
         token: ${{ inputs.token }}
 
-    - name: Tag commit
-      if: ${{ steps.publish.outputs.type != 'none' }}
+    - if: ${{ steps.publish.outputs.id }}
+      name: Tag commit
       shell: bash
       env:
-        TAG_NAME: ${{ inputs.name }}@${{ steps.publish.outputs.version }}
+        TAG_NAME: ${{ steps.publish.outputs.id }}
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
-        git tag -a "${{ env.TAG_NAME }}" -m "${{ env.TAG_NAME }}"
-        git push origin "${{ env.TAG_NAME }}"
+        git tag -a "${TAG_NAME}" -m "${TAG_NAME}"
+        git push origin "${TAG_NAME}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,26 +37,20 @@ jobs:
       - name: 'Build 🏗️'
         run: npm run build
 
-      - name: 'Configure Git for publish 🌴'
-        run: |
-
       - name: 'Publish ESLint config 🚀'
         uses: ./.github/actions/publish
         with:
-          name: '@viamrobotics/eslint-config'
-          package: packages/eslint-config/package.json
+          package: ./packages/eslint-config
           token: ${{ secrets.NPM_TOKEN }}
 
       - name: 'Publish Prettier config 🚀'
         uses: ./.github/actions/publish
         with:
-          name: '@viamrobotics/prettier-config'
-          package: packages/prettier-config/package.json
+          package: ./packages/prettier-config
           token: ${{ secrets.NPM_TOKEN }}
 
       - name: 'Publish TypeScript config 🚀'
         uses: ./.github/actions/publish
         with:
-          name: '@viamrobotics/typescript-config'
-          package: packages/typescript-config/package.json
+          package: ./packages/typescript-config
           token: ${{ secrets.NPM_TOKEN }}

--- a/packages/eslint-config/base.cjs
+++ b/packages/eslint-config/base.cjs
@@ -91,6 +91,7 @@ module.exports = {
     'no-loop-func': 'error',
     'no-multi-assign': 'error',
     'no-multi-str': 'error',
+    'no-nested-ternary': 'error',
     'no-new': 'error',
     'no-new-func': 'error',
     'no-new-native-nonconstructor': 'error',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Common ESLint configuration for Viam projects.",
   "files": [
     "**/*",


### PR DESCRIPTION
Per a request from @DTCurrie, this PR enables the `no-nested-ternary` rule.

I investigated both the vanilla rule and `unicorn/no-nested-ternary`. The Unicorn version tries to carve out an exception that allows ternary nesting if you wrap the ternary in parentheses, but this conflicts with prettier formatting. In my experience the carve-out is mostly useful for React / JSX - which isn't really a concern for us - so I went with the vanilla "just don't do it" rule instead.

It also updated the `npm-publish` action with the new and improved version while I was in here