### PR TITLE
Set prettier to use single attribute per line in Vue

### DIFF
--- a/packages/prettier-config/base.cjs
+++ b/packages/prettier-config/base.cjs
@@ -4,6 +4,7 @@ module.exports = {
   // overrides
   singleQuote: true,
   jsxSingleQuote: true,
+  singleAttributePerLine: true,
 
   // default values
   printWidth: 80,
@@ -20,5 +21,4 @@ module.exports = {
   vueIndentScriptAndStyle: false,
   endOfLine: 'lf',
   embeddedLanguageFormatting: 'auto',
-  singleAttributePerLine: false,
 };

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Common Prettier configuration for Viam projects.",
   "files": [
     "**/*",


### PR DESCRIPTION
Set the [singleAttributePerLine](https://prettier.io/docs/en/options.html#single-attribute-per-line) prettier config to `true` to match viamrobotics/app.