### PR TITLE
Allow camel-cased named imports in eslint-config

### DIFF
--- a/packages/eslint-config/base.cjs
+++ b/packages/eslint-config/base.cjs
@@ -22,7 +22,7 @@ module.exports = {
     // Extra built-in rules
     'accessor-pairs': ['error'],
     'array-callback-return': ['error', { checkForEach: true }],
-    camelcase: ['error', { properties: 'never' }],
+    camelcase: ['error', { properties: 'never', ignoreImports: true }],
     'class-methods-use-this': ['error'],
     curly: ['error', 'all'],
     'default-case-last': ['error'],

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Common ESLint configuration for Viam projects.",
   "files": [
     "**/*",


### PR DESCRIPTION
## Overview

In svelte projects, we occasionally do:

```ts
import { get_current_component } from 'svelte/internals`
```

Similarly to how we allow an exception to the `camelcase` for object properties for RPC calls, this PR adds another exception to allow for named imports