### PR TITLE
Switch prettier config back to CJS for compatibility

### DIFF
--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -14,15 +14,15 @@ pnpm add --save-dev prettier @viamrobotics/prettier-config
 ```
 
 ```js
-// .prettierrc.js
-export default '@viamrobotics/prettier-config';
+// .prettierrc.cjs
+module.exports = '@viamrobotics/prettier-config';
 ```
 
 You can also extend the configuration:
 
 ```js
-// .prettierrc.js
-import baseConfig from '@viamrobotics/prettier-config';
+// .prettierrc.cjs
+const baseConfig = require('@viamrobotics/prettier-config');
 
 export default {
   ...baseConfig,
@@ -43,6 +43,6 @@ pnpm add --save-dev \
 ```
 
 ```js
-// .prettierrc.js
-export default '@viamrobotics/prettier-config/svelte';
+// .prettierrc.cjs
+module.exports = '@viamrobotics/prettier-config/svelte';
 ```

--- a/packages/prettier-config/base.cjs
+++ b/packages/prettier-config/base.cjs
@@ -1,4 +1,6 @@
-export default {
+'use strict';
+
+module.exports = {
   // overrides
   singleQuote: true,
   jsxSingleQuote: true,

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -3,9 +3,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Common Prettier configuration for Viam projects.",
-  "type": "module",
+  "type": "commonjs",
   "files": [
     "**/*",
     "!tsconfig.json"
@@ -13,12 +13,12 @@
   "types": "./dist/base.d.cts",
   "exports": {
     ".": {
-      "types": "./dist/base.d.ts",
-      "default": "./base.js"
+      "types": "./dist/base.d.cts",
+      "default": "./base.cjs"
     },
     "./svelte": {
-      "types": "./dist/svelte.d.ts",
-      "default": "./svelte.js"
+      "types": "./dist/svelte.d.cts",
+      "default": "./svelte.cjs"
     }
   },
   "scripts": {

--- a/packages/prettier-config/svelte.cjs
+++ b/packages/prettier-config/svelte.cjs
@@ -1,6 +1,8 @@
-import baseConfig from './base.js';
+'use strict';
 
-export default {
+const baseConfig = require('./base.cjs');
+
+module.exports = {
   ...baseConfig,
   plugins: ['prettier-plugin-svelte', 'prettier-plugin-tailwindcss'],
   svelteIndentScriptAndStyle: false,

--- a/packages/prettier-config/tsconfig.json
+++ b/packages/prettier-config/tsconfig.json
@@ -6,5 +6,5 @@
     "emitDeclarationOnly": true,
     "outDir": "dist"
   },
-  "include": ["**/*.js"]
+  "include": ["**/*.cjs"]
 }


### PR DESCRIPTION
I switched the prettier config to ESM in #17 because Prettier v3 supports ESM config. However, this causes problems in consumer projects with `eslint-plugin-tailwindcss`, which attempts to defer to the prettier config. Since ESLint (for now) is still mostly CJS, this doesn't work. (Or something. Honestly I'm not 100% sure but TL;DR: ESM is not worth the pain right now)

Since ESM is allowed to `import` CJS without issue, this switches the prettier config back to good 'ol CJS to keep things working smoothly together.