### PR TITLE
APP-2482: remove unnecessary ESLint and TypeScript rules

### DIFF
--- a/packages/eslint-config/base.cjs
+++ b/packages/eslint-config/base.cjs
@@ -107,7 +107,6 @@ module.exports = {
     'no-template-curly-in-string': 'error',
     'no-unneeded-ternary': 'error',
     'no-unreachable-loop': 'error',
-    'no-undef-init': 'error',
     'no-underscore-dangle': ['error', { allow: ['__VERSION__'] }],
     'no-unmodified-loop-condition': 'error',
     'no-unused-expressions': 'error',
@@ -176,6 +175,7 @@ module.exports = {
     'unicorn/custom-error-definition': 'error',
     'unicorn/no-null': 'off',
     'unicorn/no-unused-properties': 'error',
+    'unicorn/no-useless-undefined': 'off',
     'unicorn/prefer-string-replace-all': 'error',
     'unicorn/prefer-top-level-await': 'off',
     'unicorn/prevent-abbreviations': 'off',
@@ -199,6 +199,14 @@ module.exports = {
       files: ['**/vite.config.ts', '**/vitest.config.ts'],
       rules: {
         'unicorn/prefer-module': 'off',
+      },
+    },
+    // Relax rules that don't make sense for testing
+    {
+      files: ['**/__tests__/**', '**/*.spec.ts'],
+      rules: {
+        '@typescript-eslint/no-unsafe-assignment': 'off',
+        'sonarjs/no-duplicate-string': 'off',
       },
     },
   ],

--- a/packages/eslint-config/base.cjs
+++ b/packages/eslint-config/base.cjs
@@ -152,6 +152,10 @@ module.exports = {
 
     // Extra TypeScript rules
     '@typescript-eslint/return-await': 'error',
+    '@typescript-eslint/no-confusing-void-expression': [
+      'error',
+      { ignoreArrowShorthand: true },
+    ],
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-shadow': ['error'],
     '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Common ESLint configuration for Viam projects.",
   "files": [
     "**/*",

--- a/packages/eslint-config/svelte.cjs
+++ b/packages/eslint-config/svelte.cjs
@@ -22,6 +22,14 @@ module.exports = {
       parserOptions: {
         parser: '@typescript-eslint/parser',
       },
+      rules: {
+        /*
+         * TODO(mc, 2023-08-28): this rule is crashing with svelte actions.
+         * Investigate and fix once lint dependencies are updated.
+         * https://github.com/sveltejs/eslint-plugin-svelte/issues/583
+         */
+        'sonarjs/no-unused-collection': 'off',
+      },
     },
   ],
 };

--- a/packages/eslint-config/svelte.cjs
+++ b/packages/eslint-config/svelte.cjs
@@ -25,7 +25,6 @@ module.exports = {
       rules: {
         /*
          * TODO(mc, 2023-08-28): this rule is crashing with svelte actions.
-         * Investigate and fix once lint dependencies are updated.
          * https://github.com/sveltejs/eslint-plugin-svelte/issues/583
          */
         'sonarjs/no-unused-collection': 'off',

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Common Prettier configuration for Viam projects.",
   "type": "commonjs",
   "files": [

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -32,7 +32,6 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "noPropertyAccessFromIndexSignature": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Common TypeScript configuration for Viam projects.",
   "files": [
     "**/*",


### PR DESCRIPTION
## Overview

Disable some rules that have been giving us grief:

**ESLint**

- Turn off `no-undef-init` and `unicorn/no-useless-undefined`
- In tests, turn off `@typescript-eslint/no-unsafe-assignment` and `sonarjs/no-duplicate-string`
- In `.svelte`, turn off `sonarjs/no-unused-collection` because it [crashes ESLint](https://github.com/sveltejs/eslint-plugin-svelte/issues/583)
- When using arrow functions, disable `no-confusing-void-expression` so we're not forced to use a bunch of braces in event handlers

**TypeScript**

- Turn off `noPropertyAccessFromIndexSignature`, because it's a purely stylistic concern, and it interacts poorly with with Svelte when components are accessed from `Record` objects
    - BREAKING CHANGE: this compiler option change will change linting behavior, which may cause previously passing code to start failing lint

