### PR TITLE
Continue trying to get the TypeScript exports working

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -3,17 +3,15 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Common ESLint configuration for Viam projects.",
   "files": [
     "**/*",
     "!tsconfig.json"
   ],
+  "types": "dist/base.d.cts",
   "typesVersions": {
     "*": {
-      ".": [
-        "dist/base.d.cts"
-      ],
       "svelte": [
         "dist/svelte.d.cts"
       ]

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -3,18 +3,16 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Common Prettier configuration for Viam projects.",
   "type": "commonjs",
   "files": [
     "**/*",
     "!tsconfig.json"
   ],
+  "types": "dist/base.d.cts",
   "typesVersions": {
     "*": {
-      ".": [
-        "dist/base.d.cts"
-      ],
       "svelte": [
         "dist/svelte.d.cts"
       ]


### PR DESCRIPTION
#20 got type annotations for `@viamrobotics/eslint-config/svelte` and `@viamrobotics/prettier-config/svelte` working, but broke the vanilla `@viamrobotics/eslint-config` and `@viamrobotics/prettier-config` imports.

This PR is a second stab at getting the `types` and `typesVersions` configurations correct