### PR TITLE
Ensure `cx` attributes and calls are checked for tailwind classes

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Common ESLint configuration for Viam projects.",
   "files": [
     "**/*",

--- a/packages/eslint-config/svelte.cjs
+++ b/packages/eslint-config/svelte.cjs
@@ -10,6 +10,12 @@ module.exports = {
     'plugin:svelte/recommended',
     'plugin:svelte/prettier',
   ],
+  settings: {
+    tailwindcss: {
+      callees: ['classnames', 'cx'],
+      classRegex: '^(?:class|cx)$',
+    },
+  },
   parserOptions: {
     ...baseConfig.parserOptions,
     extraFileExtensions: ['.svelte'],

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Common Prettier configuration for Viam projects.",
   "type": "commonjs",
   "files": [

--- a/packages/prettier-config/svelte.cjs
+++ b/packages/prettier-config/svelte.cjs
@@ -6,4 +6,6 @@ module.exports = {
   ...baseConfig,
   plugins: ['prettier-plugin-svelte', 'prettier-plugin-tailwindcss'],
   svelteIndentScriptAndStyle: false,
+  tailwindAttributes: ['cx'],
+  tailwindFunctions: ['classnames', 'cx'],
 };


### PR DESCRIPTION
As noticed by @DTCurrie, our linter configs weren't catching `cx` calls and attributes for sorting / checking Tailwind classes. This PR adds the necessary config to Prettier and ESLint to get that working