### PR TITLE
ESLint: remove `multiline-comment-style` rule

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "cSpell.words": [
+    "callees",
+    "camelcase",
+    "corepack",
+    "eslintconfig",
+    "falsey",
+    "isomorphically",
+    "nonconstructor",
+    "plusplus",
+    "prettierconfig",
+    "sonarjs",
+    "tailwindcss",
+    "viam",
+    "viamrobotics"
+  ]
+}

--- a/packages/eslint-config/base.cjs
+++ b/packages/eslint-config/base.cjs
@@ -59,7 +59,6 @@ module.exports = {
     'max-depth': 'error',
     'max-nested-callbacks': 'error',
     'max-statements-per-line': 'error',
-    'multiline-comment-style': 'error',
     'new-cap': 'error',
     'no-alert': 'error',
     'no-await-in-loop': 'error',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Common ESLint configuration for Viam projects.",
   "files": [
     "**/*",

--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -9,7 +9,7 @@ pnpm add --save-dev typescript @viamrobotics/typescript-config
 [viam]: https://www.viam.com/
 [typescript]: https://www.typescriptlang.org/
 
-### Base config
+## Base config
 
 Use the [base config](./tsconfig.base.json) for generic TypeScript projects, including code that runs natively in Node.js or isomorphically, in both Node.js and the browser.
 


### PR DESCRIPTION
As discussed in https://github.com/viamrobotics/prime/pull/458#discussion_r1441942477. Also took the time to add common `.vscode` settings with spell checker