### PR TITLE
Add autofixable lint to sort imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jest-dom": "^5.2.0",
+    "eslint-plugin-simple-import-sort": "^12.0.0",
     "eslint-plugin-sonarjs": "^0.25.1",
     "eslint-plugin-svelte": "^2.35.1",
     "eslint-plugin-tailwindcss": "^3.15.1",

--- a/packages/eslint-config/base.cjs
+++ b/packages/eslint-config/base.cjs
@@ -2,7 +2,7 @@
 
 module.exports = {
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'simple-import-sort'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/strict-type-checked',
@@ -170,6 +170,28 @@ module.exports = {
       },
     ],
     '@typescript-eslint/promise-function-async': 'error',
+
+    // Import sorting
+    'simple-import-sort/imports': [
+      'error',
+      {
+        groups: [
+          // Side effect imports
+          ['^\\u0000'],
+          // Node.js builtins
+          ['^node:'],
+          // Third-party packages
+          ['^vitest', '^svelte', '^@?\\w'],
+          // First-party packages
+          ['^@viamrobotics'],
+          // Anything not matched in another group, like internal $alias imports
+          ['^'],
+          // Relative imports
+          ['^\\.'],
+        ],
+      },
+    ],
+    'simple-import-sort/exports': 'error',
 
     // Extra SonarJS rules
     'sonarjs/cognitive-complexity': ['error', 20],

--- a/packages/eslint-config/base.cjs
+++ b/packages/eslint-config/base.cjs
@@ -181,7 +181,7 @@ module.exports = {
           // Node.js builtins
           ['^node:'],
           // Third-party packages
-          ['^vitest', '^svelte', '^@?\\w'],
+          ['^vitest', '^svelte', '^@sveltejs', '^@?\\w'],
           // First-party packages
           ['^@viamrobotics'],
           // Anything not matched in another group, like internal $alias imports

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Common ESLint configuration for Viam projects.",
   "files": [
     "**/*",
@@ -46,6 +46,7 @@
     "eslint": ">=8 <9",
     "eslint-config-prettier": ">=9 <10",
     "eslint-plugin-jest-dom": ">=5 <6",
+    "eslint-plugin-simple-import-sort": ">=12 <13",
     "eslint-plugin-sonarjs": ">=0.19 <0.26",
     "eslint-plugin-svelte": ">=2 <3",
     "eslint-plugin-tailwindcss": ">=3 <4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       eslint-plugin-jest-dom:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.57.0)
+      eslint-plugin-simple-import-sort:
+        specifier: ^12.0.0
+        version: 12.0.0(eslint@8.57.0)
       eslint-plugin-sonarjs:
         specifier: ^0.25.1
         version: 0.25.1(eslint@8.57.0)
@@ -1184,6 +1187,14 @@ packages:
       '@babel/runtime': 7.24.4
       eslint: 8.57.0
       requireindex: 1.2.0
+    dev: true
+
+  /eslint-plugin-simple-import-sort@12.0.0(eslint@8.57.0):
+    resolution: {integrity: sha512-8o0dVEdAkYap0Cn5kNeklaKcT1nUsa3LITWEuFk3nJifOoD+5JQGoyDUW2W/iPWwBsNBJpyJS9y4je/BgxLcyQ==}
+    peerDependencies:
+      eslint: '>=5.0.0'
+    dependencies:
+      eslint: 8.57.0
     dev: true
 
   /eslint-plugin-sonarjs@0.25.1(eslint@8.57.0):

--- a/tests/peers.spec.ts
+++ b/tests/peers.spec.ts
@@ -1,8 +1,9 @@
 /* eslint-disable unicorn/no-array-for-each */
+import fs from 'node:fs';
 import path from 'node:path';
 import url from 'node:url';
-import fs from 'node:fs';
-import { describe, it, expect } from 'vitest';
+
+import { describe, expect, it } from 'vitest';
 import semver from 'semver';
 
 interface PackageJSON {


### PR DESCRIPTION
Sort imports via [lydell/eslint-plugin-simple-import-sort](https://github.com/lydell/eslint-plugin-simple-import-sort)