### PR TITLE
Bump pnpm/actions-setup version to 4.0.0

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -22,7 +22,7 @@ runs:
       uses: pnpm/action-setup@23657c8550e9be4f7ee7e9d7fe8adda6d703bb4e # v4.0.0
 
     - name: 'Install Node.js ${{ inputs.node-version }}'
-      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -19,10 +19,10 @@ runs:
   using: 'composite'
   steps:
     - name: 'Install pnpm'
-      uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # v2.2.4
+      uses: pnpm/action-setup@23657c8550e9be4f7ee7e9d7fe8adda6d703bb4e # v4.0.0
 
     - name: 'Install Node.js ${{ inputs.node-version }}'
-      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - zp-bump
   push:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - zp-bump
   push:
     branches:
       - main


### PR DESCRIPTION
https://github.com/pnpm/pnpm/issues/6424

Causing
```
Running self-installer...
   WARN  GET https://registry.npmjs.org/pnpm error (ERR_INVALID_THIS). Will retry in 10 seconds. 2 retries left.
   WARN  GET https://registry.npmjs.org/pnpm error (ERR_INVALID_THIS). Will retry in 1 minute. 1 retries left.
   ERR_PNPM_META_FETCH_FAIL  GET https://registry.npmjs.org/pnpm: Value of "this" must be of type URLSearchParams
Error: Something went wrong, self-installer exits with code 1
```
in app

More info in private slack thread https://viaminc.slack.com/archives/C02KFSY4H89/p1720023335832159