### PR TITLE
CI: update action versions to latest

### DIFF
--- a/.github/actions/publish/action.yaml
+++ b/.github/actions/publish/action.yaml
@@ -15,7 +15,7 @@ runs:
   steps:
     - id: publish
       name: Publish package
-      uses: JS-DevTools/npm-publish@0be441d808570461daedc3fb178405dbcac54de0
+      uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c # v3.1.1
       with:
         package: ${{ inputs.package }}
         token: ${{ inputs.token }}

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -19,10 +19,10 @@ runs:
   using: 'composite'
   steps:
     - name: 'Install pnpm'
-      uses: pnpm/action-setup@23657c8550e9be4f7ee7e9d7fe8adda6d703bb4e # v4.0.0
+      uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
     - name: 'Install Node.js ${{ inputs.node-version }}'
-      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+      uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Install 🔧'
         uses: ./.github/actions/setup
@@ -29,7 +29,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Install 🔧'
         uses: ./.github/actions/setup


### PR DESCRIPTION
## Overview

Bump action versions in shared actions and workflows.

> [!IMPORTANT]  
> This will bump these actions in workflows across the org

## Change log

- Shared actions
    - Bump `actions/setup-node` to latest to fix deprecation warnings
    - Bump `JS-DevTools/npm-publish` to latest to fix deprecation warnings
    - Fix commit hash for `pnpm/action-setup`
- Internal workflows
    - Update to `actions/checkout@v4`