### PR TITLE
fix(prettier-config): avoid bundling TS build info and deps

### DIFF
--- a/packages/prettier-config-svelte/.npmignore
+++ b/packages/prettier-config-svelte/.npmignore
@@ -1,0 +1,2 @@
+tsconfig.json
+*.tsbuildinfo

--- a/packages/prettier-config-svelte/package.json
+++ b/packages/prettier-config-svelte/package.json
@@ -4,13 +4,9 @@
     "access": "public",
     "provenance": true
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Viam's shared Prettier configuration for Svelte projects.",
   "type": "module",
-  "files": [
-    "**/*",
-    "!tsconfig.json"
-  ],
   "types": "./dist/prettier-config-svelte.d.ts",
   "exports": {
     ".": {

--- a/packages/prettier-config/.npmignore
+++ b/packages/prettier-config/.npmignore
@@ -1,0 +1,2 @@
+tsconfig.json
+*.tsbuildinfo

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -4,13 +4,9 @@
     "access": "public",
     "provenance": true
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Viam's shared Prettier configuration.",
   "type": "module",
-  "files": [
-    "**/*",
-    "!tsconfig.json"
-  ],
   "types": "./dist/prettier-config.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
## Overview

Small tweak to the publish settings for the prettier configs after examining the published bundles

1. #48
2. #49
3. 🌿 #51 
4. #50
5. TODO: Update ESLint packages to use ESLint v9 and flat configs

## Change log

Switched from the `files` allowlist to an `.npmignore` blocklist since it's (apparently for my brain) a little less error prone

- Remove `**/*` from `files` to prevent bundling `node_modules` into the tarball
- Ignore `*.tsbuildinfo`
