### PR TITLE
fix(eslint-config): disable rules that are triggering due to plugin bugs

### DIFF
--- a/packages/eslint-config-svelte/eslint-config-svelte.js
+++ b/packages/eslint-config-svelte/eslint-config-svelte.js
@@ -46,7 +46,8 @@ const baseSvelteConfig = createConfig(
       },
     },
     rules: {
-      // Too many false positives
+      // TODO(mc, 2024-02-14): Too many false positives
+      // https://github.com/sveltejs/eslint-plugin-svelte/issues/1073
       'svelte/require-stores-init': 'off',
     },
   },
@@ -57,6 +58,14 @@ const baseSvelteConfig = createConfig(
     rules: {
       // Allows us to set option props to `undefined` by default
       'no-undef-init': 'off',
+
+      // TODO(mc, 2024-11-06): False positive with props
+      // https://github.com/sveltejs/eslint-plugin-svelte/issues/476
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+
+      // Svelte ESLint parser does not type snippets correctly
+      // https://github.com/sveltejs/svelte-eslint-parser/issues/657
+      '@typescript-eslint/no-confusing-void-expression': 'off',
     },
   },
 

--- a/packages/eslint-config-svelte/package.json
+++ b/packages/eslint-config-svelte/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ESLint configuration for Svelte projects at Viam.",
   "type": "module",
   "main": "./eslint-config-svelte.js",

--- a/packages/eslint-config/eslint-config.js
+++ b/packages/eslint-config/eslint-config.js
@@ -268,6 +268,10 @@ const baseConfig = createConfig(
         { pattern: String.raw`.*\.spec\.(ts|svelte)$` },
       ],
       'vitest/consistent-test-it': ['error', { fn: 'it' }],
+      'vitest/expect-expect': [
+        'error',
+        { assertFunctionNames: ['expect', 'expect*'] },
+      ],
       'vitest/no-conditional-expect': 'error',
       'vitest/no-conditional-in-test': 'error',
       'vitest/no-conditional-tests': 'error',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "provenance": true
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ESLint configuration for projects at Viam.",
   "type": "module",
   "main": "./eslint-config.js",


### PR DESCRIPTION
This PR makes a few rules more lenient based on starting to use Svelte 5 and finding a few patterns and bugs in the Svelte ESLint plugin