### PR TITLE
fix(eslint-config-svelte): disable no-unsafe-call due to parser bug

### DIFF
--- a/packages/eslint-config-svelte/eslint-config-svelte.js
+++ b/packages/eslint-config-svelte/eslint-config-svelte.js
@@ -66,6 +66,10 @@ const baseSvelteConfig = createConfig(
       // Svelte ESLint parser does not type snippets correctly
       // https://github.com/sveltejs/svelte-eslint-parser/issues/657
       '@typescript-eslint/no-confusing-void-expression': 'off',
+
+      // Svelte ESLint parser can lose function prop types
+      // https://github.com/sveltejs/svelte-eslint-parser/issues/608
+      '@typescript-eslint/no-unsafe-call': 'off',
     },
   },
 

--- a/packages/eslint-config-svelte/package.json
+++ b/packages/eslint-config-svelte/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "ESLint configuration for Svelte projects at Viam.",
   "type": "module",
   "main": "./eslint-config-svelte.js",


### PR DESCRIPTION
Frequent false positives in Svelte 5 components from this rule due to parser somehow losing type information that TS has