### PR TITLE
Svelte: disable no-unsafe-assignment in .svelte and .svelte.ts for runes

### DIFF
--- a/packages/eslint-config-svelte/eslint-config-svelte.js
+++ b/packages/eslint-config-svelte/eslint-config-svelte.js
@@ -54,7 +54,7 @@ const baseSvelteConfig = createConfig(
 
   {
     name: 'viam/svelte/svelte-base',
-    files: ['**/*.svelte'],
+    files: ['**/*.svelte', '**/*.svelte.ts'],
     rules: {
       // Allows us to set option props to `undefined` by default
       'no-undef-init': 'off',
@@ -70,6 +70,9 @@ const baseSvelteConfig = createConfig(
       // Svelte ESLint parser can lose function prop types
       // https://github.com/sveltejs/svelte-eslint-parser/issues/608
       '@typescript-eslint/no-unsafe-call': 'off',
+
+      // Svelte ESLint parser can lose types with $props.id() and other runes
+      '@typescript-eslint/no-unsafe-assignment': 'off',
     },
   },
 

--- a/packages/eslint-config-svelte/package.json
+++ b/packages/eslint-config-svelte/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "ESLint configuration for Svelte projects at Viam.",
   "type": "module",
   "main": "./eslint-config-svelte.js",


### PR DESCRIPTION
Another one from trying to use [`$props.id()`](https://svelte.dev/docs/svelte/$props#$props.id())