### PR TITLE
Update 'prefer-const' destructuring rule from 'any' to 'all'

### DIFF
--- a/packages/eslint-config/eslint-config.js
+++ b/packages/eslint-config/eslint-config.js
@@ -126,7 +126,7 @@ const baseConfig = createConfig(
       'operator-assignment': 'error',
       'padding-line-between-statements': 'error',
       'prefer-arrow-callback': 'error',
-      'prefer-const': 'error',
+      'prefer-const': ['error', { destructuring: 'all' }],
       'prefer-exponentiation-operator': 'error',
       'prefer-named-capture-group': 'error',
       'prefer-numeric-literals': 'error',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "provenance": true
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "ESLint configuration for projects at Viam.",
   "type": "module",
   "main": "./eslint-config.js",


### PR DESCRIPTION
From the rule docs:

> "any" (default) - If any variables in destructuring should be const, this rule warns for those variables.
"all" - If all variables in destructuring should be const, this rule warns the variables. Otherwise, ignores them.

The current behavior will complain if _any_ field in a destructured object should be a `const`. This can be an issue in a case where you may want to use a destructured object where some fields are intended to change and others aren't. For example, in the case of using the `$bindable` rune in Svelte 5:

```svelte
<script lang="ts">
interface Props {
  thing: string;
  element: HTMLDivElement | undefined
}

let { thing, element = $bindable() } = $props();
</script>

<div bind:this={element}></div>
```

In the above, a `const` _cannot_ be use for a `$bindable` prop, so we must use `let`; however, the current rule would complain because `thing` should be treated a `const`. 

