### PR TITLE
Remove NODE_AUTH_TOKEN from publish step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,5 +41,3 @@ jobs:
 
       - name: 'Publish 🚀'
         run: pnpm publish --recursive
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Removed NODE_AUTH_TOKEN environment variable from publish step, so we can use OIDC trusted publishing