### PR TITLE
drop eslint-plugin-jest-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,6 @@
     "update-dependencies": "pnpm update --recursive --interactive --latest"
   },
   "packageManager": "pnpm@10.7.1+sha512.2d92c86b7928dc8284f53494fb4201f983da65f0fb4f0d40baafa5cf628fa31dae3e5968f12466f17df7e97310e30f343a648baea1b9b350685dafafffdf5808",
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "eslint-plugin-jest-dom>eslint": "^10.0.0"
-      }
-    }
-  },
   "devDependencies": {
     "@types/node": "^22.14.0",
     "@types/semver": "^7.7.0",

--- a/packages/eslint-config-svelte/eslint-config-svelte.js
+++ b/packages/eslint-config-svelte/eslint-config-svelte.js
@@ -1,4 +1,3 @@
-import jestDOM from 'eslint-plugin-jest-dom';
 import svelte from 'eslint-plugin-svelte';
 import testingLibrary from 'eslint-plugin-testing-library';
 import globals from 'globals';
@@ -67,10 +66,7 @@ const baseSvelteConfig = defineConfig(
 
   {
     name: 'viam/svelte/component-testing',
-    extends: [
-      jestDOM.configs['flat/recommended'],
-      testingLibrary.configs['flat/dom'],
-    ],
+    extends: [testingLibrary.configs['flat/dom']],
     files: ['**/__tests__/**', '**/*.test.ts', '**/*.spec.ts'],
     rules: {
       ...testingLibrary.configs['flat/dom'].rules,

--- a/packages/eslint-config-svelte/package.json
+++ b/packages/eslint-config-svelte/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "ESLint configuration for Svelte projects at Viam.",
   "type": "module",
   "main": "./eslint-config-svelte.js",
@@ -28,7 +28,6 @@
   "dependencies": {
     "@typescript-eslint/utils": "~8.59.2",
     "@viamrobotics/eslint-config": "workspace:^",
-    "eslint-plugin-jest-dom": "~5.5.0",
     "eslint-plugin-svelte": "~3.17.1",
     "eslint-plugin-testing-library": "~7.16.2",
     "globals": "^17.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ importers:
       '@viamrobotics/eslint-config':
         specifier: workspace:^
         version: link:../eslint-config
-      eslint-plugin-jest-dom:
-        specifier: ~5.5.0
-        version: 5.5.0(eslint@10.3.0(jiti@1.21.6))
       eslint-plugin-svelte:
         specifier: ~3.17.1
         version: 3.17.1(eslint@10.3.0(jiti@1.21.6))(svelte@5.25.7)
@@ -135,10 +132,6 @@ packages:
 
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/runtime@7.24.5':
-    resolution: {integrity: sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==}
     engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.25.2':
@@ -907,16 +900,6 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-plugin-jest-dom@5.5.0:
-    resolution: {integrity: sha512-CRlXfchTr7EgC3tDI7MGHY6QjdJU5Vv2RPaeeGtkXUHnKZf04kgzMPIJUXt4qKCvYWVVIEo9ut9Oq1vgXAykEA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6', yarn: '>=1'}
-    peerDependencies:
-      '@testing-library/dom': ^8.0.0 || ^9.0.0 || ^10.0.0
-      eslint: ^6.8.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
-    peerDependenciesMeta:
-      '@testing-library/dom':
-        optional: true
-
   eslint-plugin-perfectionist@5.9.0:
     resolution: {integrity: sha512-8TWzg02zmnBdZwCkWLi8jhzqXI+fE7Z/RwV8SL6xD45tJ8Bp3wGuYL2XtQgfe/Wd0eBqOUX+s6ey73IyszvKTA==}
     engines: {node: ^20.0.0 || >=22.0.0}
@@ -1484,9 +1467,6 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  regenerator-runtime@0.14.1:
-    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
-
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
@@ -1498,10 +1478,6 @@ packages:
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
-
-  requireindex@1.2.0:
-    resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
-    engines: {node: '>=0.10.5'}
 
   resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
@@ -1834,10 +1810,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
 
   '@babel/helper-validator-identifier@7.28.5': {}
-
-  '@babel/runtime@7.24.5':
-    dependencies:
-      regenerator-runtime: 0.14.1
 
   '@esbuild/aix-ppc64@0.25.2':
     optional: true
@@ -2520,12 +2492,6 @@ snapshots:
     dependencies:
       eslint: 10.3.0(jiti@1.21.6)
 
-  eslint-plugin-jest-dom@5.5.0(eslint@10.3.0(jiti@1.21.6)):
-    dependencies:
-      '@babel/runtime': 7.24.5
-      eslint: 10.3.0(jiti@1.21.6)
-      requireindex: 1.2.0
-
   eslint-plugin-perfectionist@5.9.0(eslint@10.3.0(jiti@1.21.6))(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/utils': 8.59.2(eslint@10.3.0(jiti@1.21.6))(typescript@5.8.3)
@@ -3012,8 +2978,6 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
-  regenerator-runtime@0.14.1: {}
-
   regexp-tree@0.1.27: {}
 
   regjsparser@0.13.1:
@@ -3021,8 +2985,6 @@ snapshots:
       jsesc: 3.1.0
 
   require-directory@2.1.1: {}
-
-  requireindex@1.2.0: {}
 
   resolve@1.22.8:
     dependencies:


### PR DESCRIPTION
This plugin is essentially dead, see: https://github.com/testing-library/eslint-plugin-jest-dom/issues/417#issuecomment-4020145175

Best to just drop it and figure out if there is a better tool to use.